### PR TITLE
Avoid duplicate release pipeline in Github Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,6 @@ on:
   release:
     types:
       - published
-      - created
-      - edited
 
 jobs:
   publish:


### PR DESCRIPTION
Really we only need to publish to crates.io when a release is _published_ on Github.